### PR TITLE
fix: Add entrypoint to docker-compose

### DIFF
--- a/future/docker-compose.yaml
+++ b/future/docker-compose.yaml
@@ -9,6 +9,10 @@ services:
     volumes:
       - "$PWD/notebooks:/notebooks"
       - "$PWD/jupyter_config.py:/home/jovyan/.jupyter/jupyter_config.py"
+    entrypoint:
+      - jupyter
+      - lab
+      - --allow-root
     depends_on:
       - nginx
       - vaurien_delay


### PR DESCRIPTION
- Bind-mounting for docker causes problem
    - 'uid' is set as user outside container
    - It causes permission denied issue
- It occurs because of the base command of jupyter image
    - Base command of image is running built-in shell script
    - The script creates user 'jovyan'
    - and run jupyter lab as jovyan
- So it is needed to change user to 'root'
    - set user as 'root' and change entrypoint

Signed-off-by: sukim96 <sungwoong.kim@enerzai.com>